### PR TITLE
automation: Update el9stream container tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     container: quay.io/centos/centos:${{ matrix.version.tag }}
     strategy:
       matrix:
-        version: [ { tag: stream8, name: centos-8 }, { tag: stream9-development, name: centos-9 } ]
+        version: [ { tag: stream8, name: centos-8 }, { tag: stream9, name: centos-9 } ]
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
The el9stream has released, now the centos container
image provides tag el9stream, use that instead of
el9stream-development.