### PR TITLE
Use oVirt upload rpms action v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build RPMs
       run: ./automation/rpm.sh
-    - uses: ovirt/upload-rpms-action@v1
+    - uses: ovirt/upload-rpms-action@v2
       with:
         directory: ${{ env.EXPORT_DIR }}
-        distro: ${{ matrix.distro }}


### PR DESCRIPTION
The second version is able to detect
distro of builder, so it is no longer needed
to pass it as argument.